### PR TITLE
Use channels instead of mutex locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ Notice the lack of order of entries.
 ...
 ```
 
+## Benchmark
+
+Running `go test -bench .`
+
+```
+goos: linux
+goarch: amd64
+pkg: github.com/tsak/concurrent-csv-writer
+BenchmarkCsvWriter_Write/nil-slice-8              794725              1512 ns/op
+BenchmarkCsvWriter_Write/row-8                    735760              1586 ns/op
+PASS
+ok      github.com/tsak/concurrent-csv-writer   4.202s
+```
+
 ## License
 
 [MIT](https://github.com/tsak/concurrent-csv-writer/blob/master/LICENSE)

--- a/csv_writer.go
+++ b/csv_writer.go
@@ -1,57 +1,121 @@
-// Package ccsv provides a "thread" safe way of writing to CSV files
+// Package ccsv provides a concurrency safe way of writing to CSV files from multiple go routines
 package ccsv
 
 import (
 	"encoding/csv"
+	"errors"
+	"log"
 	"os"
-	"sync"
 )
 
-// CsvWriter holds pointers to a Mutex, csv.Writer and the underlying CSV file
+// CsvWriter encapsulates the underlying os.File, a csv.Writer, a data channel, a done channel and
+// a flag that determines if a writer is already closed
 type CsvWriter struct {
-	mutex     *sync.Mutex
-	csvWriter *csv.Writer
-	file      *os.File
+	file   *os.File
+	writer *csv.Writer
+	data   chan []string
+	done   chan bool
+	closed bool
 }
 
-// NewCsvWriter creates a CSV file and returns a CsvWriter
-func NewCsvWriter(fileName string) (*CsvWriter, error) {
-	csvFile, err := os.Create(fileName)
+var ErrWriterClosed = errors.New("ccsv: writer already closed")
+
+// NewCsvWriter creates a CSV file and returns a pointer to a new CsvWriter
+// Will return an error if the underlying os.Create fails for some reason
+func NewCsvWriter(filename string) (*CsvWriter, error) {
+	file, err := os.Create(filename)
 	if err != nil {
 		return nil, err
 	}
-	w := csv.NewWriter(csvFile)
-	return &CsvWriter{csvWriter: w, mutex: &sync.Mutex{}, file: csvFile}, nil
+
+	ccsvwriter := CsvWriter{
+		file:   file,
+		writer: csv.NewWriter(file),
+		data:   make(chan []string),
+		done:   make(chan bool),
+	}
+
+	go ccsvwriter.loop()
+
+	return &ccsvwriter, nil
+}
+
+// loop handles writes via channel and closing the writer if the data channel is closed
+func (c *CsvWriter) loop() {
+	for {
+		select {
+		case msg, ok := <-c.data:
+			// Data channel was closed, let's wrap things up
+			if !ok {
+				c.closed = true
+				// Flush any pending writes
+				c.writer.Flush()
+				if err := c.writer.Error(); err != nil {
+					log.Println("Error", err)
+				}
+				if err := c.file.Close(); err != nil {
+					log.Println(err)
+				}
+				c.done <- true
+				return
+			}
+			if err := c.writer.Write(msg); err != nil {
+				log.Println(err)
+			}
+			if err := c.writer.Error(); err != nil {
+				log.Println("Error", err)
+			}
+		}
+	}
 }
 
 // Write a single row to a CSV file
-func (w *CsvWriter) Write(row []string) error {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-	return w.csvWriter.Write(row)
+// Will return a ErrWriterClosed error if the CsvWriter was closed before
+func (c *CsvWriter) Write(row []string) (err error) {
+	defer func() {
+		// Any pending writes once the data channel is closed can result in a panic, this will recover from it
+		if recover() != nil {
+			err = ErrWriterClosed
+		}
+	}()
+
+	if c.closed {
+		return ErrWriterClosed
+	}
+	c.data <- row
+	return
 }
 
 // WriteAll writes multiple rows to a CSV file
-func (w *CsvWriter) WriteAll(records [][]string) error {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-	return w.csvWriter.WriteAll(records)
+// Will return a ErrWriterClosed error if the CsvWriter was closed before
+func (c *CsvWriter) WriteAll(rows [][]string) error {
+	for _, row := range rows {
+		if err := c.Write(row); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Flush writes any pending rows
-func (w *CsvWriter) Flush() error {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-	w.csvWriter.Flush()
-	return w.csvWriter.Error()
+// Will return a ErrWriterClosed error if the CsvWriter was closed before
+func (c *CsvWriter) Flush() error {
+	if c.closed {
+		return ErrWriterClosed
+	}
+	c.writer.Flush()
+	return c.writer.Error()
 }
 
 // Close CSV file for writing
 // Implicitly calls Flush() before
-func (w *CsvWriter) Close() error {
-	err := w.Flush()
-	if err != nil {
-		return err
+// Will return a ErrWriterClosed error if the CsvWriter was closed before
+func (c *CsvWriter) Close() error {
+	if c.closed {
+		return ErrWriterClosed
 	}
-	return w.file.Close()
+	close(c.data)
+	<-c.done
+	close(c.done)
+	return nil
 }


### PR DESCRIPTION
This is a rewrite, using channels instead of mutex locks.

So far, mutex locking wins over channels...

```bash
# Mutex locks
BenchmarkCsvWriter_Write/nil-slice-8              886317              1353 ns/op
BenchmarkCsvWriter_Write/row-8                    795957              1492 ns/op

# Channels
BenchmarkCsvWriter_Write/nil-slice-8              788208              1523 ns/op
BenchmarkCsvWriter_Write/row-8                    753146              1571 ns/op
```